### PR TITLE
fix: fix broken opinion article url

### DIFF
--- a/src/components/ArticleSquare.astro
+++ b/src/components/ArticleSquare.astro
@@ -6,7 +6,8 @@ const date = {
 	day: _date_obj.getDate(),
 	year: _date_obj.getFullYear(),
 };
-const url = `/opinion/${entry.id}`; // todo: find a way to use this
+const baseUrl = import.meta.env.BASE_URL;
+const url = `${baseUrl}/opinion/${entry.id}`; // todo: find a way to use this
 // and to have one for author too.
 ---
 


### PR DESCRIPTION
## Summary

This pr fixes the broken link `xzbfsf.github.io/opinion/[article id]` to correct `xzbfsf.github.io/www/opinion/[article id]`.

## Details

Added the base url `/www` at the beginning of the url. more info at #5 